### PR TITLE
removing generation_key & ssl_generation_key from thread local storage

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -1109,6 +1109,9 @@ class Net::HTTP::Persistent
 
     thread[@request_key] = nil
     thread[@timeout_key] = nil
+
+    thread[@generation_key] = nil
+    thread[@ssl_generation_key] = nil
   end
 
   ##

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -1473,14 +1473,14 @@ class TestNetHttpPersistent < Minitest::Test
 
     assert c.finished?, 'connection in same thread must be finished'
 
-    assert_empty Thread.current[@http.generation_key]
+    assert_nil Thread.current[@http.generation_key]
 
     assert_nil Thread.current[@http.request_key]
 
     t.run
     assert t.value.finished?, 'connection in other thread must be finished'
 
-    assert_empty t[@http.generation_key]
+    assert_nil t[@http.generation_key]
 
     assert_nil t[@http.request_key]
   end
@@ -1505,8 +1505,8 @@ class TestNetHttpPersistent < Minitest::Test
 
     @http.shutdown
 
-    assert_empty Thread.current[@http.generation_key]
-    assert_empty Thread.current[@http.ssl_generation_key]
+    assert_nil Thread.current[@http.generation_key]
+    assert_nil Thread.current[@http.ssl_generation_key]
 
     assert_nil Thread.current[@http.request_key]
     assert_nil Thread.current[@http.timeout_key]
@@ -1547,8 +1547,8 @@ class TestNetHttpPersistent < Minitest::Test
 
     t.run
     assert t.value.finished?
-    assert_empty t[@http.generation_key]
-    assert_empty t[@http.ssl_generation_key]
+    assert_nil t[@http.generation_key]
+    assert_nil t[@http.ssl_generation_key]
     assert_nil t[@http.request_key]
     assert_nil t[@http.timeout_key]
   end


### PR DESCRIPTION
since we are closing all connections, we want to make sure we don’t
leave any cruft in thread local storage.
